### PR TITLE
Default rom folder, menus and submenus, tabs and argument path fix.

### DIFF
--- a/CxBx-Reloaded.pro.user
+++ b/CxBx-Reloaded.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.5.1, 2018-04-22T20:38:21. -->
+<!-- Written by QtCreator 4.5.1, 2018-04-27T23:22:37. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/CxBx-Reloaded.pro.user
+++ b/CxBx-Reloaded.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.5.1, 2018-04-10T20:14:18. -->
+<!-- Written by QtCreator 4.5.1, 2018-04-22T20:38:21. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -8,7 +8,7 @@
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
-  <value type="int">2</value>
+  <value type="int">1</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.EditorSettings</variable>
@@ -292,7 +292,7 @@
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">gui/gui.pro</value>
     <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">D:/Repositorio/build-CxBx-Reloaded-Desktop_Qt_5_10_1_MSVC2017_64bit-Debug/gui</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">D:/Repositorio/build-CxBx-Reloaded-Desktop_Qt_5_10_1_MSVC2015_64bit-Debug/gui</value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
@@ -531,12 +531,15 @@
     </valuelist>
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Arguments"></value>
-    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Executable"></value>
-    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.WorkingDirectory">%{buildDir}</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Custom Executable</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">gui</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.CustomExecutableRunConfiguration</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:D:/Repositorio/CxBx-R-Branch-L/gui/gui.pro</value>
+    <value type="bool" key="QmakeProjectManager.QmakeRunConfiguration.UseLibrarySearchPath">true</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.CommandLineArguments"></value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">gui/gui.pro</value>
+    <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">D:/Repositorio/build-CxBx-Reloaded-Desktop_Qt_5_10_1_MSVC2015_64bit-Debug/gui</value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
@@ -783,7 +786,7 @@
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">gui/gui.pro</value>
     <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">D:/Repositorio/build-CxBx-Reloaded-Desktop_Qt_5_10_1_MSVC2017_64bit-Debug/gui</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">D:/Repositorio/build-CxBx-Reloaded-Desktop_Qt_5_10_1_MSVC2015_64bit-Debug/gui</value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>

--- a/CxBx-Reloaded.pro.user
+++ b/CxBx-Reloaded.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.5.1, 2018-04-27T23:22:37. -->
+<!-- Written by QtCreator 4.5.1, 2018-04-29T20:10:52. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/gui/config.cpp
+++ b/gui/config.cpp
@@ -12,15 +12,36 @@ Config::Config()
     settingsConfig = new QSettings(dir + "/CXBX-Reloaded/config.ini", QSettings::IniFormat);
 }
 
-QString Config::loadDirectory()
+QStringList Config::loadDirectory()
 {
-    qDebug() << "CONFIG CLASS, METHOD LOADDIRECTORY: " << "In";
-    return this->settingsConfig->value("CXBX_EXE", "").toString();
+    this->settingsConfig->beginGroup("Directories");
+
+    QString dir = this->settingsConfig->value("CXBX_EXE", "").toString();
+    QString rom = this->settingsConfig->value("ROMS", "").toString();
+
+    QStringList listDir;
+    listDir.append(dir);
+    listDir.append(rom);
+
+    this->settingsConfig->endGroup();
+    return listDir;
 }
 
-void Config::saveDirectory(QString path)
+void Config::saveDirectory(QString cxbxPath, QString romsPath)
 {
-    qDebug() << "CONFIG CLASS, METHOD SAVEDIRECTORY: " << path;
-    this->settingsConfig->setValue("CXBX_EXE", path);
-    qDebug() << "CONFIG CLASS, METHOD SAVEDIRECTORY: " << "Done";
+    qDebug() << "CONFIG CLASS, METHOD SAVEDIRECTORY: " << cxbxPath;
+    qDebug() << "CONFIG CLASS, METHOD SAVEDIRECTORY: " << romsPath;
+    this->settingsConfig->beginGroup("Directories");
+    this->settingsConfig->setValue("CXBX_EXE", cxbxPath);
+    this->settingsConfig->setValue("ROMS", romsPath);
+    this->settingsConfig->endGroup();
+}
+
+void Config::saveEmulation()
+{
+    this->settingsConfig->beginGroup("Emulation");
+    this->settingsConfig->setValue("LLE_JIT", false);
+    this->settingsConfig->setValue("LLE_APU", false);
+    this->settingsConfig->setValue("LLE_GPU", false);
+    this->settingsConfig->endGroup();
 }

--- a/gui/config.cpp
+++ b/gui/config.cpp
@@ -24,6 +24,7 @@ QStringList Config::loadDirectory()
     listDir.append(rom);
 
     this->settingsConfig->endGroup();
+
     return listDir;
 }
 
@@ -32,8 +33,10 @@ void Config::saveDirectory(QString cxbxPath, QString romsPath)
     qDebug() << "CONFIG CLASS, METHOD SAVEDIRECTORY: " << cxbxPath;
     qDebug() << "CONFIG CLASS, METHOD SAVEDIRECTORY: " << romsPath;
     this->settingsConfig->beginGroup("Directories");
+
     this->settingsConfig->setValue("CXBX_EXE", cxbxPath);
     this->settingsConfig->setValue("ROMS", romsPath);
+
     this->settingsConfig->endGroup();
 }
 

--- a/gui/config.h
+++ b/gui/config.h
@@ -2,14 +2,16 @@
 #define CONFIG_H
 
 #include <QSettings>
+#include <QStringList>
 
 
 class Config
 {
 public:
     Config();
-    QString loadDirectory();
-    void saveDirectory(QString path);
+    QStringList loadDirectory();
+    void saveDirectory(QString cxbxPath, QString romsPath);
+    void saveEmulation();
 
 private:
     QSettings *settingsConfig;

--- a/gui/emu_settings.cpp
+++ b/gui/emu_settings.cpp
@@ -11,7 +11,8 @@ Emu_Settings::Emu_Settings(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    this->ui->edtCxbx->setText(configClass.loadDirectory().trimmed());
+    this->ui->edtCxbx->setText(configClass.loadDirectory()[0]);
+    this->ui->edtRoms->setText(configClass.loadDirectory()[1]);
 }
 
 Emu_Settings::~Emu_Settings()
@@ -34,12 +35,16 @@ void Emu_Settings::on_btnSearch_Cxbx_clicked()
     this->ui->edtCxbx->setText(directory);
 }
 
-/*Search path of roms. Maybe will be removed.*/
 void Emu_Settings::on_btnSearch_Roms_clicked()
 {
-    /*QString directory = QFileDialog::getExistingDirectory(this, tr("Select the rom dir"), nullptr, QFileDialog::ShowDirsOnly);
-    dir->setDirRom(directory);
-    this->ui->edtRoms->setText(dir->getDirRom());*/
+    QString qlDirRoms = this->ui->edtRoms->text().trimmed();
+    QString directory = QFileDialog::getExistingDirectory(this, tr("Select roms directory"), "", QFileDialog::ShowDirsOnly);
+    qDebug() << directory;
+
+    if(directory.isEmpty())
+        directory = qlDirRoms;
+
+    this->ui->edtRoms->setText(directory);
 }
 
 /*Save Config in a ini file. Key, Value*/
@@ -47,7 +52,10 @@ void Emu_Settings::on_buttonBox_accepted()
 {
     /*Check QLineEdit is filled*/
     if(!ui->edtCxbx->text().isEmpty()){
-        configClass.saveDirectory(this->ui->edtCxbx->text().trimmed());
+        QString cxbxPath = this->ui->edtCxbx->text().trimmed();
+        QString romsPath = this->ui->edtRoms->text().trimmed();
+        configClass.saveDirectory(cxbxPath, romsPath);
+        configClass.saveEmulation();
     }
 
     /*Close emu_settings.ui dialog*/

--- a/gui/emu_settings.h
+++ b/gui/emu_settings.h
@@ -24,7 +24,6 @@ private slots:
     void on_buttonBox_accepted();
     void on_buttonBox_rejected();
 
-
 private:
     Ui::Emu_Settings *ui;
     Config configClass;

--- a/gui/emu_settings.ui
+++ b/gui/emu_settings.ui
@@ -41,7 +41,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="emulationTab">
       <attribute name="title">
@@ -105,6 +105,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="cbPatchCPU">
+            <property name="text">
+             <string>Patch CPU Frequency (rdtsc)</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -142,7 +149,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="cboxDisplayAdapter"/>
+           <widget class="QComboBox" name="combDisplayAdapter"/>
           </item>
           <item>
            <widget class="QLabel" name="lblAPI">
@@ -152,7 +159,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="cboxAPI"/>
+           <widget class="QComboBox" name="combAPI"/>
           </item>
           <item>
            <widget class="QLabel" name="lblVideoResolution">
@@ -162,7 +169,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="cboxVideoResolution"/>
+           <widget class="QComboBox" name="combVideoResolution"/>
           </item>
           <item>
            <widget class="QCheckBox" name="cbUseHardwareVideo">
@@ -222,7 +229,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="cboxAudioAdapter"/>
+           <widget class="QComboBox" name="combAudioAdapter"/>
           </item>
           <item>
            <widget class="QCheckBox" name="cbEnablePCM">
@@ -260,6 +267,20 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="controllerTab">
+      <attribute name="title">
+       <string>Controller</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_13">
+       <item>
+        <widget class="QCheckBox" name="cbXinput">
+         <property name="text">
+          <string>XInput</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -347,6 +368,339 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="eepronTab">
+      <attribute name="title">
+       <string>Eepron</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_12">
+       <item>
+        <layout class="QHBoxLayout" name="hlConfunder">
+         <item>
+          <widget class="QLabel" name="lblConfunder">
+           <property name="text">
+            <string>Confounder</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtConfunder">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlHDDKey">
+         <item>
+          <widget class="QLabel" name="lblHDDKey">
+           <property name="text">
+            <string>HDD Key</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtHDDKey">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlXboxRegion">
+         <item>
+          <widget class="QLabel" name="lblXboxRegion">
+           <property name="text">
+            <string>Xbox Region</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combXboxRegion">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlSerialNum">
+         <item>
+          <widget class="QLabel" name="lblSerialNum">
+           <property name="text">
+            <string>Serial Number</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtSerialNum">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlMacAddress">
+         <item>
+          <widget class="QLabel" name="lblMacAddress">
+           <property name="text">
+            <string>MAC Address</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtMacAddress">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlOnlineKey">
+         <item>
+          <widget class="QLabel" name="lblOnlineKey">
+           <property name="text">
+            <string>Online Key</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtOnlineKey">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlAvRegion">
+         <item>
+          <widget class="QLabel" name="lblAvRegion">
+           <property name="text">
+            <string>AV Region</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combAvRegion">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlLanguage">
+         <item>
+          <widget class="QLabel" name="lblLanguage">
+           <property name="text">
+            <string>Language</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combLanguage">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlVideoSettings">
+         <item>
+          <widget class="QLabel" name="lblVideoSettings">
+           <property name="text">
+            <string>Video Settings</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combVideoSettings">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlAudioSettings">
+         <item>
+          <widget class="QLabel" name="lblAudioSettings">
+           <property name="text">
+            <string>Audio Settings</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combAudioSettings">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlGameParental">
+         <item>
+          <widget class="QLabel" name="lblGameParental">
+           <property name="text">
+            <string>Game Parental Control</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combGameParental">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlParentalPass">
+         <item>
+          <widget class="QLabel" name="lblParentalPass">
+           <property name="text">
+            <string>Parental Password</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtParentalPass">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlMovieParental">
+         <item>
+          <widget class="QLabel" name="lblMovieParental">
+           <property name="text">
+            <string>Movie Parental Control</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combMovieParental">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlDVDRegion">
+         <item>
+          <widget class="QLabel" name="lblDVDRegion">
+           <property name="text">
+            <string>DVD Region</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="combDVDRegion">
+           <property name="maximumSize">
+            <size>
+             <width>225</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlColorSystem">
+         <item>
+          <widget class="QCheckBox" name="cbNtsc1080i">
+           <property name="text">
+            <string>PAL 60Hz</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="cbNtsc480">
+           <property name="text">
+            <string>NTSC 480p</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="cbPal60">
+           <property name="text">
+            <string>NTSC 720p</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="cbNtsc720">
+           <property name="text">
+            <string>NTSC 1080i</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/gui/emu_settings.ui
+++ b/gui/emu_settings.ui
@@ -41,7 +41,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="emulationTab">
       <attribute name="title">
@@ -319,7 +319,7 @@
             <item>
              <widget class="QLineEdit" name="edtRoms">
               <property name="enabled">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -16,20 +16,20 @@ MainWindow::MainWindow(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    QString appData = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+    //QString appData = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
 
-    this->settings = new QSettings(appData + "/cxbx-reloaded/conf.ini", QSettings::IniFormat);
+    //this->settings = new QSettings(appData + "/cxbx-reloaded/conf.ini", QSettings::IniFormat);
 
     this->gameTableView = this->findChild<QTableView*>("gameTableView");
 
-    this->gameTableView->setModel(new XbeTableModel(this->settings->value("game_dir").toString()));
+    this->gameTableView->setModel(new XbeTableModel(configClass.loadDirectory()[1]));
     this->gameTableView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
 }
 
 MainWindow::~MainWindow()
 {
     delete ui;
-    delete this->settings;
+    //delete this->settings;
 }
 
 //Simple exit instruction
@@ -59,7 +59,7 @@ void MainWindow::on_actionEmulationStart_triggered()
     QString xbePath = model->getXbe(index)->m_szPath;
 
     /*Emulator runs, but doesn't execute the game in the path.*/
-    QString program = configClass.loadDirectory();
+    QString program = configClass.loadDirectory()[0];
     this->emulatorProcess.start(program, QStringList() << xbePath);
 }
 
@@ -72,7 +72,7 @@ void MainWindow::on_actionOpen_Xbe_triggered()
    //Run the .xbe as an argument for the emulator if the argument isn't empty
     if (!fileName.isEmpty()){
 
-        QString program = configClass.loadDirectory();
+        QString program = configClass.loadDirectory()[0];
         qDebug() << "MAINWINDOW, configClass: " << program;
         QStringList arguments;
         QString temp_path; // = "\"" + fileName + "\""; enquotations are not working for some reason?

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -57,9 +57,11 @@ void MainWindow::on_actionEmulationStart_triggered()
 
     QString xbePath = model->getXbe(index)->m_szPath;
 
-    /*Emulator runs, but doesn't execute the game in the path.*/
-    QString program = configClass.loadDirectory()[0];
-    this->emulatorProcess.start(program, QStringList() << xbePath);
+    /*Runs Cxbx process.*/
+    QString cxbxDir = configClass.loadDirectory()[0];
+    QStringList arguments;
+    arguments.append(QDir::toNativeSeparators(xbePath));
+    this->runCxbx(cxbxDir, arguments);
 }
 
 //Open a dialog window to load an .xbe and run on the emulator
@@ -70,17 +72,11 @@ void MainWindow::on_actionOpen_Xbe_triggered()
 
    //Run the .xbe as an argument for the emulator if the argument isn't empty
     if (!fileName.isEmpty()){
-
-        QString program = configClass.loadDirectory()[0];
-        qDebug() << "MAINWINDOW, configClass: " << program;
+        QString cxbxDir = configClass.loadDirectory()[0];
+        qDebug() << "MAINWINDOW, configClass: " << cxbxDir;
         QStringList arguments;
-        QString temp_path; // = "\"" + fileName + "\""; enquotations are not working for some reason?
-        temp_path = QDir::toNativeSeparators(fileName); //QDir::toNativeSeparators makes sure the path obtained by QFileDialog::getOpenFileName is valid as a native path
-        arguments << temp_path;
-
-        QProcess *myProcess = new QProcess(qApp);
-        myProcess->start(program, arguments);
-
+        arguments.append(QDir::toNativeSeparators(fileName)); //QDir::toNativeSeparators makes sure the path obtained by QFileDialog::getOpenFileName is valid as a native path
+        this->runCxbx(cxbxDir, arguments);
       }
 }
 
@@ -103,8 +99,8 @@ void MainWindow::on_actionEmulation_triggered()
 
 void MainWindow::on_actionEmulationStop_triggered()
 {
-    if(this->emulatorProcess.state() == QProcess::Running)
-        this->emulatorProcess.terminate();
+    if(this->emulatorProcess->isOpen())
+        this->emulatorProcess->terminate();
 }
 
 void MainWindow::on_actionVideo_triggered()
@@ -112,4 +108,11 @@ void MainWindow::on_actionVideo_triggered()
     emu = new Emu_Settings(this);
     emu->setModal(true);
     emu->show();
+}
+
+/*Runs Cxbx process.*/
+void MainWindow::runCxbx(QString cxbxDir, QStringList arguments)
+{
+    emulatorProcess = new QProcess(this);
+    this->emulatorProcess->start(cxbxDir, arguments);
 }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -21,7 +21,6 @@ MainWindow::MainWindow(QWidget *parent) :
     //this->settings = new QSettings(appData + "/cxbx-reloaded/conf.ini", QSettings::IniFormat);
 
     this->gameTableView = this->findChild<QTableView*>("gameTableView");
-
     this->gameTableView->setModel(new XbeTableModel(configClass.loadDirectory()[1]));
     this->gameTableView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
 }
@@ -80,21 +79,21 @@ void MainWindow::on_actionOpen_Xbe_triggered()
         arguments << temp_path;
 
         QProcess *myProcess = new QProcess(qApp);
-        myProcess->start(program,arguments);
+        myProcess->start(program, arguments);
 
       }
 }
 
 
-//Load the About window
+//Load About window
 void MainWindow::on_actionAbout_triggered()
 {
-    about = new About();
+    about = new About(this);
     about->setModal(true);
     about->show();
 }
 
-//Load the Emulation settings window
+//Load Emulation settings window
 void MainWindow::on_actionEmulation_triggered()
 {
     emu = new Emu_Settings(this);

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -47,11 +47,13 @@ private:
     Ui::MainWindow *ui;
     QTableView *gameTableView;
     //QSettings *settings;
-    QProcess emulatorProcess;
+    QProcess *emulatorProcess;
 
     Emu_Settings *emu;
     About *about;
     Config configClass;
+
+    void runCxbx(QString cxbxDir, QStringList arguments);
 };
 
 #endif // MAINWINDOW_H

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -46,7 +46,7 @@ private slots:
 private:
     Ui::MainWindow *ui;
     QTableView *gameTableView;
-    QSettings *settings;
+    //QSettings *settings;
     QProcess emulatorProcess;
 
     Emu_Settings *emu;

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -77,27 +77,33 @@
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
-   <widget class="QMenu" name="menuEdit">
-    <property name="title">
-     <string>Edit</string>
-    </property>
-   </widget>
    <widget class="QMenu" name="menuSettings">
     <property name="title">
      <string>Settings</string>
     </property>
+    <widget class="QMenu" name="menuHLE_Cache">
+     <property name="title">
+      <string>HLE Cache</string>
+     </property>
+     <addaction name="actionClear"/>
+     <addaction name="actionRescan"/>
+    </widget>
     <addaction name="actionController"/>
     <addaction name="actionVideo"/>
     <addaction name="actionSound"/>
     <addaction name="separator"/>
     <addaction name="actionEmulation"/>
     <addaction name="separator"/>
-    <addaction name="actionHLE_Cache"/>
+    <addaction name="menuHLE_Cache"/>
    </widget>
    <widget class="QMenu" name="menuEmulation">
     <property name="title">
      <string>Emulation</string>
     </property>
+    <addaction name="actionStart"/>
+    <addaction name="actionStart_Debugger"/>
+    <addaction name="separator"/>
+    <addaction name="actionStop"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -111,13 +117,26 @@
     <property name="title">
      <string>Debug</string>
     </property>
-    <addaction name="actionOutput_GUI"/>
-    <addaction name="actionOutput_Kernel"/>
+    <widget class="QMenu" name="menuOutput_GUI">
+     <property name="title">
+      <string>Output (GUI)</string>
+     </property>
+     <addaction name="actionConsole"/>
+     <addaction name="actionFile"/>
+    </widget>
+    <widget class="QMenu" name="menuOutput_Kernel">
+     <property name="title">
+      <string>Output (Kernel)</string>
+     </property>
+     <addaction name="actionConsole_2"/>
+     <addaction name="actionFile_2"/>
+    </widget>
+    <addaction name="menuOutput_GUI"/>
+    <addaction name="menuOutput_Kernel"/>
    </widget>
    <addaction name="menuFile"/>
-   <addaction name="menuEdit"/>
-   <addaction name="menuSettings"/>
    <addaction name="menuEmulation"/>
+   <addaction name="menuSettings"/>
    <addaction name="menuHelp"/>
    <addaction name="menuDebug"/>
   </widget>
@@ -240,19 +259,49 @@
     <string>Emulation</string>
    </property>
   </action>
-  <action name="actionOutput_GUI">
+  <action name="actionConsole">
    <property name="text">
-    <string>Output (GUI)</string>
+    <string>Console</string>
    </property>
   </action>
-  <action name="actionOutput_Kernel">
+  <action name="actionFile">
    <property name="text">
-    <string>Output (Kernel)</string>
+    <string>File...</string>
    </property>
   </action>
-  <action name="actionHLE_Cache">
+  <action name="actionConsole_2">
    <property name="text">
-    <string>HLE Cache</string>
+    <string>Console</string>
+   </property>
+  </action>
+  <action name="actionFile_2">
+   <property name="text">
+    <string>File...</string>
+   </property>
+  </action>
+  <action name="actionClear">
+   <property name="text">
+    <string>Clear entire HLE cache</string>
+   </property>
+  </action>
+  <action name="actionRescan">
+   <property name="text">
+    <string>Rescan title HLE cache</string>
+   </property>
+  </action>
+  <action name="actionStart">
+   <property name="text">
+    <string>Start</string>
+   </property>
+  </action>
+  <action name="actionStop">
+   <property name="text">
+    <string>Stop</string>
+   </property>
+  </action>
+  <action name="actionStart_Debugger">
+   <property name="text">
+    <string>Start Debugger...</string>
    </property>
   </action>
  </widget>

--- a/gui/models/xbetablemodel.cpp
+++ b/gui/models/xbetablemodel.cpp
@@ -43,9 +43,11 @@ QVariant XbeTableModel::data(const QModelIndex &index, int role) const
 
 void XbeTableModel::scanDirectory(QString directory)
 {
-    QDirIterator it(directory, QStringList() << "*.xbe", QDir::Files,
+    /*QDirIterator it(directory, QStringList() << "*.xbe", QDir::Files,
+                    QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);*/
+    QDirIterator it(directory, QStringList() << "Default.xbe", QDir::Files,
                     QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
-    Xbe *xbe = NULL;
+    Xbe *xbe = nullptr;
 
     while(it.hasNext()) {
         QString nextFile = it.next();


### PR DESCRIPTION
- Now you are able to search a default rom folder.
- Added some menus and submenus: 
> Emulation: Start, Start Debbugger, Stop.
>      Debug: Console and File in GUI and Kernel, 
>      HLE Cache: Clear entire HLE cache, Rescan title HLE cache.


- Added controller and eepron tabs.
- Fixed argument path on actionEmulationStart method. Play button works now.